### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ tags        : generates etags files
 dox         : generates the doxygen documentation if Doxyfile exists
 clear       : cleans up *~ #* and dependencies
 clean       : cleans up .o lib and exe files
-cleanaux    : cleans auxilary files: *.o *.d
+cleanaux    : cleans auxiliary files: *.o *.d
 cleandep    : cleans up the dependency files
 cleandox    : cleans up the documentation
 cleandist   : cleans everything except source+headers


### PR DESCRIPTION
etola, I've corrected a typographical error in the documentation of the [makefile-heaven](https://github.com/etola/makefile-heaven) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
